### PR TITLE
Fix error on setting address' device via api

### DIFF
--- a/api/v2/controllers/Addresses.php
+++ b/api/v2/controllers/Addresses.php
@@ -376,7 +376,7 @@ class Addresses_controller extends Common_api_functions  {
 
 		// validate device
 		if(isset($this->_params->switch)) {
-		if($this->Tools->fetch_object("devices", "vlanId", $this->_params->switch)===false)	{ $this->Response->throw_exception(400, "Device does not exist"); } }
+		if($this->Tools->fetch_object("devices", "id", $this->_params->switch)===false)	{ $this->Response->throw_exception(400, "Device does not exist"); } }
 		// validate state
 		if(isset($this->_params->state)) {
 		if($this->Tools->fetch_object("ipTags", "id", $this->_params->state)===false)		{ $this->Response->throw_exception(400, "Tag does not exist"); } }


### PR DESCRIPTION
Fix the error "Error: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'vlanId' in 'where clause'" when creating address with device via api.
